### PR TITLE
Update version number to reflect new Python 3.0 compatibility

### DIFF
--- a/proxy/views.py
+++ b/proxy/views.py
@@ -30,7 +30,7 @@ def proxy_view(request, url, requests_args=None):
 
     # If there's a content-length header from Django, it's probably in all-caps
     # and requests might not notice it, so just remove it.
-    for key in headers.keys():
+    for key in list(headers.keys()):
         if key.lower() == 'content-length':
             del headers[key]
 
@@ -63,7 +63,7 @@ def proxy_view(request, url, requests_args=None):
         # should be.
         'content-length',
     ])
-    for key, value in response.headers.iteritems():
+    for key, value in response.headers.items():
         if key.lower() in excluded_headers:
             continue
         proxy_response[key] = value
@@ -77,7 +77,7 @@ def get_headers(environ):
     https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.META
     """
     headers = {}
-    for key, value in environ.iteritems():
+    for key, value in environ.items():
         # Sometimes, things don't like when you send the requesting host through.
         if key.startswith('HTTP_') and key != 'HTTP_HOST':
             headers[key[5:].replace('_', '-')] = value

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ def get_package_data(package):
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 


### PR DESCRIPTION
Force pushed an amended commit message and created a new pr since I noticed the previous pr attempt included a commit which omitted the new version number in the message.